### PR TITLE
Input type parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='speak2mary',
-      version='1.4.0',
+      version='1.5.0',
       description='A Python wrapper for Mary TTS',
       long_description=open('README.md').read(),
       long_description_content_type="text/markdown",
@@ -13,6 +13,7 @@ setup(name='speak2mary',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
       ],
       license='Apache License - Version 2.0',
       package_dir={'speak2mary': 'speak2mary'},

--- a/speak2mary/__init__.py
+++ b/speak2mary/__init__.py
@@ -18,13 +18,15 @@ class MaryTTS(object):
                  port=DEFAULT_PORT,
                  codec=DEFAULT_CODEC,
                  locale=DEFAULT_LOCALE,
-                 voice=DEFAULT_VOICE):
+                 voice=DEFAULT_VOICE,
+                 input_type=DEFAULT_INPUT_TYPE):
 
         self._host = host
         self._port = port
         self._codec = codec
         self._locale = locale
         self._voice = voice
+        self._input_type = input_type
 
     def speak(self, message, effects=None):
         if effects is None:
@@ -32,8 +34,8 @@ class MaryTTS(object):
 
         raw_params = {
             "INPUT_TEXT": message.encode('UTF8'),
-            "INPUT_TYPE": DEFAULT_INPUT_TYPE,
             "OUTPUT_TYPE": DEFAULT_OUTPUT_TYPE,
+            "INPUT_TYPE": self._input_type,
             "LOCALE": self._locale,
             "AUDIO": self._codec,
             "VOICE": self._voice,

--- a/tests/test_marytts.py
+++ b/tests/test_marytts.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 import wave
 from io import BytesIO
@@ -27,3 +26,24 @@ class TestMaryTTS(unittest.TestCase):
         self.assertEqual(waves.getnchannels(), 1)
         self.assertEqual(waves.getframerate(), 48000)
         self.assertGreater(waves.getnframes(), 10000)
+
+    def test_speak_as_emotionalxml(self):
+        mary = MaryTTS(input_type="EMOTIONML")
+
+        xml = """
+        <emotionml version="1.0" xmlns="http://www.w3.org/2009/10/emotionml" 
+        category-set="http://www.w3.org/TR/emotion-voc/xml#everyday-categories">        
+            <emotion><category name="angry"/>
+                Hello World
+            </emotion>
+        </emotionml>
+        """
+
+        audio = mary.speak(xml)
+        waves = wave.open(BytesIO(audio))
+
+        self.assertEqual(waves.getnchannels(), 1)
+        self.assertEqual(waves.getframerate(), 48000)
+        self.assertGreater(waves.getnframes(), 10000)
+        # Make sure only "Hello World" is in the output, not the whole xml
+        self.assertLess(len(audio), 200000)


### PR DESCRIPTION
This gives the opportunity to specify also the `INPUT_TYPE` parameter of MaryTTS.

Will close #1 